### PR TITLE
Fix product search parameter order

### DIFF
--- a/web_ui/pages/Assistant.py
+++ b/web_ui/pages/Assistant.py
@@ -376,8 +376,8 @@ if st.session_state.messages[-1]["role"] != "assistant":
                             query = answer.split('keywords:')[-1]
                             products = product_search(query,
                                   product_search_invoke_url,
-                                  model_name,
                                   index,
+                                  model_name,
                                   product_search_sagemaker_endpoint,
                                   reranker_sagemaker_endpoint,
                                   search_type,


### PR DESCRIPTION
*Issue #, if available:*
Product Search is invoked with the wrong parameter order; "index" and "modelName" are swapped
 
*Description of changes:*
Changed parameter order line 377

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
